### PR TITLE
Fix multigpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,15 @@ endif()
 #check if we are building for DRM
 if(SFML_DRM)
     add_definitions(-DSFML_DRM)
+find_path(LIBGBM_INCLUDE_DIRS
+    NAMES gbm.h
+    HINTS ${PC_LIBGBM_INCLUDE_DIRS} ${PC_LIBGBM_INCUDEDIR}
+)
+
+find_library(LIBGBM_LIBRARIES
+    NAMES gbm
+    HINTS ${PC_LIBGBM_LIBRARY_DIRS} ${PC_LIBGBM_LIBDIR}
+)
 endif()
 
 # define SFML_OPENGL_ES if needed

--- a/src/SFML/Window/Unix/DRM/drm-common.c
+++ b/src/SFML/Window/Unix/DRM/drm-common.c
@@ -151,10 +151,27 @@ static uint32_t find_crtc_for_connector(const struct drm *drm, const drmModeRes 
 
 static int get_resources(int fd, drmModeRes **resources)
 {
+	drmModeConnector *conn;
+	unsigned int i;
+	int ret = -1;
 	*resources = drmModeGetResources(fd);
 	if (*resources == NULL)
 		return -1;
-	return 0;
+	for (i = 0; i < (*resources)->count_connectors; ++i) {
+		/* get information for each connector */
+		conn = drmModeGetConnector(fd, (*resources)->connectors[i]);
+		if (!conn) {
+			drmModeFreeConnector(conn);
+			continue;
+		}
+		if (conn->connection == DRM_MODE_CONNECTED) {
+			ret = 0;
+			break;
+		}
+		drmModeFreeConnector(conn);
+	}
+	drmModeFreeConnector(conn);
+	return ret;
 }
 
 #define MAX_DRM_DEVICES 64


### PR DESCRIPTION
This PR fixes SFML choosing a video card that has no output connected thus crashing later. This can happen on PCs with multiple GPUs (like onboard video + dedicated GFX card), where the 1st card (onboard video) has no output conected. Until now, SFML wouldn't care about the connectors state and select a card that in the end can't be used for rendering.

This fix will select the first video card that has at least one connector connected.

At the same time, I've added a cmake fix on detecting GBM headers and lib. This way, missing gbm.h will be detected when running cmake, not when building.